### PR TITLE
Update version to 0.0.4 properly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic.io/component-commons-library",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
I didn't update it properly the first time. I manually changed the version in `package.json` instead of doing `npm version 0.0.4` and consequently missed the version in `package-lock.json`.